### PR TITLE
Secret_key must be 32 url-safe` base64-encoded bytes

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,13 +12,15 @@ from middlewares import db_handler, authorize
 from motor import motor_asyncio as ma
 from settings import *
 
+import hashlib
+
 
 async def on_shutdown(app):
     for ws in app['websockets']:
         await ws.close(code=1001, message='Server shutdown')
 
 middle = [
-    session_middleware(EncryptedCookieStorage(SECRET_KEY)),
+    session_middleware(EncryptedCookieStorage(hashlib.sha256(bytes(SECRET_KEY, 'utf-8')).digest())),
     authorize,
     db_handler,
 ]


### PR DESCRIPTION
Secret_key must be 32 url-safe` base64-encoded bytes "base64.urlsafe_b64decode(fernet_key)"
>>    return binascii.a2b_base64(s)
>>binascii.Error: Incorrect padding

https://github.com/aio-libs/aiohttp/issues/1042#issuecomment-237274714